### PR TITLE
Added compatibility with LuckPerms.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ base {
 repositories {
 	maven { url = "https://maven.terraformersmc.com/releases/" }
 	maven { url = "https://maven.isxander.dev/releases" }
+	maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
 loom {
@@ -30,6 +31,8 @@ dependencies {
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
+
+	modImplementation include("me.lucko:fabric-permissions-api:0.3.3")
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
 	modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 
-	modImplementation include("me.lucko:fabric-permissions-api:0.3.3")
+	modImplementation include("me.lucko:fabric-permissions-api:0.3.1")
 }
 
 processResources {

--- a/src/main/java/one/oth3r/sit/command/SitCommand.java
+++ b/src/main/java/one/oth3r/sit/command/SitCommand.java
@@ -14,17 +14,21 @@ import one.oth3r.sit.utl.Data;
 import one.oth3r.sit.utl.Logic;
 import one.oth3r.sit.utl.Utl;
 
+import me.lucko.fabric.api.permissions.v0.Permissions;
+
 import java.util.concurrent.CompletableFuture;
 
 public class SitCommand {
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
         dispatcher.register(CommandManager.literal("sit")
-                .requires((commandSource) -> commandSource.hasPermissionLevel(0))
-                .executes((context2) -> command(context2.getSource(), context2.getInput()))
-                .then(CommandManager.argument("args", StringArgumentType.string())
-                        .requires((commandSource) -> commandSource.hasPermissionLevel(2))
-                        .suggests(SitCommand::getSuggestions)
-                        .executes((context2) -> command(context2.getSource(), context2.getInput()))));
+                .requires(Permissions.require("sit.use", 0))
+                        .executes((context2) -> sitUse(context2.getSource()))
+                // .executes((context2) -> command(context2.getSource(), context2.getInput()))
+                // .then(CommandManager.argument("args", StringArgumentType.string())
+                //         .requires((commandSource) -> commandSource.hasPermissionLevel(2))
+                //         .suggests(SitCommand::getSuggestions)
+                //         .executes((context2) -> command(context2.getSource(), context2.getInput()))));
+        );
     }
 
     public static CompletableFuture<Suggestions> getSuggestions(CommandContext<ServerCommandSource> context, SuggestionsBuilder builder) {
@@ -33,31 +37,11 @@ public class SitCommand {
         return builder.buildFuture();
     }
 
-    private static int command(ServerCommandSource source, String arg) {
+    // sit command
+    private static int sitUse(ServerCommandSource source) {
         ServerPlayerEntity player = source.getPlayer();
-        // trim all the arguments before the command (for commands like /execute)
-        int index = arg.indexOf("sit");
-        // trims the words before the text
-        if (index != -1) arg = arg.substring(index).trim();
 
-        String[] args = arg.split(" ");
-        // if command string starts with sit, remove it
-        if (args[0].equalsIgnoreCase("sit"))
-            args = arg.replaceFirst("sit ", "").split(" ");
-
-        // if console
-        if (player == null) {
-            if (args[0].equalsIgnoreCase("reload")) {
-                Logic.reload();
-                Data.LOGGER.info(Utl.lang("sit!.chat.reloaded").getString());
-            }
-            return 1;
-        }
-
-        // player
-
-        if (args[0].equalsIgnoreCase("sit")) {
-            // if the player can't sit where they're looking, try to sit below
+        if (player != null) {
             if (!Logic.sitLooking(player)) {
                 BlockPos pos = player.getBlockPos();
 
@@ -72,13 +56,30 @@ public class SitCommand {
                 Logic.sit(player, pos, null);
             }
         }
+        return 1;
+    }
 
-        if (args[0].equalsIgnoreCase("reload")) {
+    // reload command
+    private static int sitReload(ServerCommandSource source) {
+        ServerPlayerEntity player = source.getPlayer();
+
+        if (player != null) {
             Logic.reload();
             player.sendMessage(Utl.messageTag().append(Utl.lang("sit!.chat.reloaded").formatted(Formatting.GREEN)));
+        } else {
+            Logic.reload();
+            Data.LOGGER.info(Utl.lang("sit!.chat.reloaded").getString());
         }
+        return 1;
+    }
 
-        if (args[0].equalsIgnoreCase("purgeChairEntities")) Utl.Entity.purge(player,true);
+    // purge command
+    private static int sitPurge(ServerCommandSource source) {
+        ServerPlayerEntity player = source.getPlayer();
+
+        if (player != null) {
+            Utl.Entity.purge(player,true);
+        }
         return 1;
     }
 }

--- a/src/main/java/one/oth3r/sit/command/SitCommand.java
+++ b/src/main/java/one/oth3r/sit/command/SitCommand.java
@@ -15,6 +15,7 @@ import one.oth3r.sit.utl.Logic;
 import one.oth3r.sit.utl.Utl;
 
 import me.lucko.fabric.api.permissions.v0.Permissions;
+import static net.minecraft.server.command.CommandManager.literal;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -23,19 +24,17 @@ public class SitCommand {
         dispatcher.register(CommandManager.literal("sit")
                 .requires(Permissions.require("sit.use", 0))
                         .executes((context2) -> sitUse(context2.getSource()))
-                // .executes((context2) -> command(context2.getSource(), context2.getInput()))
-                // .then(CommandManager.argument("args", StringArgumentType.string())
-                //         .requires((commandSource) -> commandSource.hasPermissionLevel(2))
-                //         .suggests(SitCommand::getSuggestions)
-                //         .executes((context2) -> command(context2.getSource(), context2.getInput()))));
+                .then(literal("reload")
+                    .requires(Permissions.require("sit.reload", 2))
+                        .executes((context2) -> sitReload(context2.getSource()))
+                )
+                .then(literal("purgeChairEntities")
+                    .requires(Permissions.require("sit.reload", 2))
+                        .executes((context2) -> sitPurge(context2.getSource()))
+                )
         );
     }
 
-    public static CompletableFuture<Suggestions> getSuggestions(CommandContext<ServerCommandSource> context, SuggestionsBuilder builder) {
-        builder.suggest("reload");
-        builder.suggest("purgeChairEntities");
-        return builder.buildFuture();
-    }
 
     // sit command
     private static int sitUse(ServerCommandSource source) {

--- a/src/main/java/one/oth3r/sit/utl/Logic.java
+++ b/src/main/java/one/oth3r/sit/utl/Logic.java
@@ -15,6 +15,8 @@ import one.oth3r.sit.file.SittingConfig;
 import one.oth3r.sit.file.HandSetting;
 import org.jetbrains.annotations.Nullable;
 
+import me.lucko.fabric.api.permissions.v0.Permissions;
+
 public class Logic {
     public static boolean sit(ServerPlayerEntity player, BlockPos blockPos, @Nullable BlockHitResult hitResult) {
         // cant sit if crouching
@@ -57,6 +59,9 @@ public class Logic {
      */
     public static boolean checkHands(ServerPlayerEntity player) {
         SittingConfig sittingConfig = FileData.getPlayerSetting(player);
+        // no permissions
+        if (!Permissions.check(player, "sit.use", 0)) return false;
+
         // if can't sit with hand, false
         if (!sittingConfig.canSitWithHand()) return false;
 


### PR DESCRIPTION
Permissions to sit, reload and purge entities can be controlled by a permission manager such as LuckPerms.
Disabling sit also disables using empty hand to sit.
Should not have changed any default behaviour.
